### PR TITLE
Fix link to the directory containing figures

### DIFF
--- a/book1.html
+++ b/book1.html
@@ -29,7 +29,7 @@ by <a href="https://www.cs.ubc.ca/~murphyk/">Kevin Patrick Murphy</a>.
 		  or
 		  <a href="https://www.amazon.com/Probabilistic-Machine-Learning-Introduction-Computation/dp/0262046822">Amazon</a>..
 	  
-	<li> <a href="https://github.com/probml/pml-book/tree/main/book1-figures/images">Figures from the book</a> (png files)
+	<li> <a href="https://github.com/probml/pml-book/tree/main/book1-figures">Figures from the book</a> (png files)
 		
 	<li> <a href="https://github.com/probml/pyprobml/tree/master/notebooks/book1">
 	    Code to reproduce most of the figures</a> 


### PR DESCRIPTION
PNG files now live here: https://github.com/probml/pml-book/tree/main/book1-figures/ 